### PR TITLE
fix author and date in blog items

### DIFF
--- a/templates/item.html.twig
+++ b/templates/item.html.twig
@@ -17,7 +17,7 @@
                     {% if page.header.subheading %}
                     <h2 class="subheading">{{ page.header.subheading }}</h2>
                     {% endif %}
-                    <span class="meta">{{ 'THEME_CLEAN_BLOG.POST_BY'|t }} {{ post.header.author }} {{ 'THEME_CLEAN_BLOG.POST_ON'|t }} {{ post.date|date(dateformat) }}</span>
+                    <span class="meta">{{ 'THEME_CLEAN_BLOG.POST_BY'|t }} {{ page.header.author }} {{ 'THEME_CLEAN_BLOG.POST_ON'|t }} {{ page.date|date(dateformat) }}</span>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
`header.author` and `date` should come from the `page` object, not `post`. `post` isn't a valid object (probably a copy paste mistake).