### PR TITLE
Fixed <article>...</div> mismatch

### DIFF
--- a/templates/item.html.twig
+++ b/templates/item.html.twig
@@ -34,5 +34,5 @@
             </div>
         </div>
     </div>
-</div>
+</article>
 {% endblock %}


### PR DESCRIPTION
For consistency, open & close the section with either `<div>...</div>` or `<article>...</article>` elements. Also, in the case of blog posts, it is [W3C's Recommendation in HTML 5.1 ](http://w3c.github.io/html/sections.html#elementdef-article) to use the `<article>` element in this context.