### PR TITLE
Add JSComment to item-template

### DIFF
--- a/templates/item.html.twig
+++ b/templates/item.html.twig
@@ -34,6 +34,9 @@
         <div class="row">
             <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
                 {{ page.content }}
+                {% if config.plugins.jscomments.enabled %}
+                    {{ jscomments() }}
+                {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
Since this is a blog-theme and many blogs offer a comment-solution I would prefer one, too. So installing and enabling the plugin `JSComment` can now work out of the box with this theme.