### PR TITLE
contact form fields were not displaying because of incorrect variable

### DIFF
--- a/templates/contact.html.twig
+++ b/templates/contact.html.twig
@@ -5,7 +5,8 @@
     <div class="row">
         <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
             {{ page.content }}
-            {% include "forms/form.html.twig" with { forms: "contact-form" } %}
+            {% set contact_form = attribute(page.header.forms, 'contact-form') %}
+            {% include "forms/form.html.twig" with { form: contact_form } %}
         </div>
     </div>
 </div>


### PR DESCRIPTION
contact form is not working for me after installing this theme. fields do not appear under the content.  this fixes that.