### PR TITLE
Display post summary on collection page

### DIFF
--- a/templates/blog.html.twig
+++ b/templates/blog.html.twig
@@ -19,6 +19,9 @@
                         {{ 'THEME_CLEAN_BLOG.POST_BY'|t }} {{ post.header.author }}
                         {{ 'THEME_CLEAN_BLOG.POST_ON'|t }} {{ post.date|date(dateformat) }}
                     </p>
+                    <p class="post-preview">
+                        {{ post.summary|raw }}
+                    </p>
                 </div>
                 <!-- Divider-->
                 <hr class="my-4" />


### PR DESCRIPTION
The sample shows the post summaries, but it was displaying with Grav 1.7.

Fixes #23